### PR TITLE
refactor(docker): simplify Docker configuration and remove unused build args

### DIFF
--- a/.docker/docker-compose.dev.yaml
+++ b/.docker/docker-compose.dev.yaml
@@ -1,32 +1,11 @@
 services:
   # Defines a service name
   workspace:
-    build:
-      # Sets the build context to the current directory
-      context: .
-      # Specifies the Dockerfile to use for the build
-      dockerfile: .docker/Dockerfile.dev
-      # Specifies build-time variables (ARGs)
-      args:
-        ARG_BUILD_FROM: $BUILD_FROM
-        ARG_USERNAME: $CONTAINER_USERNAME
-        ARG_USER_UID: $CONTAINER_USER_UID
-        ARG_USER_GID: $CONTAINER_USER_GID
-        ARG_WORKSPACE_ROOT: $CONTAINER_WORKSPACE_ROOT
-        ARG_USER_FULLNAME: $CONTAINER_USER_FULLNAME
-        ARG_USER_EMAIL: $CONTAINER_USER_EMAIL
-        ARG_GITHUB_USERNAME: $GITHUB_USERNAME
-        ARG_SYSTEM_HOSTNAME: $CONTAINER_HOSTNAME
-        ARG_WORKSPACE_LOCATION: $CONTAINER_WORKSPACE_LOCATION
-        ARG_DOTFILES_VERSION: $DOTFILES_VERSION
-        ARG_APP_INSTALL_ROOT: $APP_INSTALL_ROOT
-        ARG_APP_DIRNAME: $APP_DIRNAME
-        ARG_CONTAINER_SERVICE_NAME: $CONTAINER_SERVICE_NAME
     # Sets the image name for the built image
-    image: $IMAGE_NAME:$IMAGE_TAG
+    image: ghcr.io/entelecheia/devcon:0.4.1-ubuntu-22.04
     # Sets the hostname of the container
     hostname: $CONTAINER_HOSTNAME
-    
+
     # Sets tty to true if the container needs a pseudo-TTY
     tty: true
     stdin_open: true

--- a/.docker/docker.common.env
+++ b/.docker/docker.common.env
@@ -23,7 +23,7 @@ HOST_SCRIPTS_DIR=${HOST_SCRIPTS_DIR:-"$HOST_WORKSPACE_ROOT/scripts"}
 HOST_SSH_DIR=${HOST_SSH_DIR:-"$HOST_WORKSPACE_LOCATION/.ssh"}
 HOST_CACHE_DIR=${HOST_CACHE_DIR:-"$HOST_WORKSPACE_LOCATION/.cache"}
 HOST_HF_HOME=${HOST_HF_HOME:-"$HOST_CACHE_DIR/huggingface"}
-HOST_SOURCE_DIR=${HOST_SOURCE_DIR:-"$PWD/src"}
+HOST_SOURCE_DIR=${HOST_SOURCE_DIR:-"$PWD"}
 
 #######################################################################################
 # Please do not make any changes below this line if you don't know what you are doing #

--- a/Makefile
+++ b/Makefile
@@ -106,17 +106,9 @@ reinit-docker-project: install-copier ## Reinitialize the docker project (Warnin
 # Docker Operations   #
 #######################
 
-docker-build: ## Build the Docker image (variant: IMAGE_VARIANT, default: dev)
-	$(call log,Building Docker image)
-	$(call run_docker,build)
-
 docker-config: ## Show the Docker Compose configuration
 	$(call log,Showing Docker Compose configuration)
 	$(call run_docker,config)
-
-docker-push: ## Push the Docker image to registry
-	$(call log,Pushing Docker image)
-	$(call run_docker,push)
 
 docker-run: ## Run a command in the Docker container (default: bash)
 	$(call log,Running Docker container)
@@ -133,10 +125,6 @@ docker-up-detach: ## Start the Docker container in detached mode
 docker-down: ## Stop and remove the Docker container
 	$(call log,Stopping and removing Docker container)
 	$(call run_docker,down)
-
-docker-tag: ## Tag the Docker image as latest
-	$(call log,Tagging Docker image as latest)
-	$(call run_docker,tag)
 
 docker-clean: ## Remove all Docker artifacts (images, containers, volumes)
 	$(call log,Removing all Docker artifacts)


### PR DESCRIPTION
## Summary by Sourcery

Simplify the Docker configuration by removing unused build arguments and commands from the Makefile. The Docker image is now pulled from `ghcr.io/entelecheia/devcon:0.4.1-ubuntu-22.04` instead of being built locally.

Chores:
- Remove the `docker-build`, `docker-push`, and `docker-tag` commands from the Makefile.
- Remove unused build arguments from the Docker configuration.